### PR TITLE
Fix catching corrupted date time in storage

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedFeedingSession.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedFeedingSession.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -69,6 +70,8 @@ class JsonAdaptedFeedingSession {
             modelDateTime = LocalDateTime.parse(dateTime, DATE_TIME_FORMATTER);
         } catch (IllegalArgumentException e) {
             throw new IllegalValueException("Invalid UUID or DateTime format");
+        } catch (DateTimeParseException e) {
+            throw new IllegalValueException("Corrupted DateTime field: " + dateTime);
         }
 
         final String modelNotes = notes != null ? notes : "";


### PR DESCRIPTION
Fix #267 
- Catch the DateTimeParseException that might occur in corrupted data files where the Date Time format is incorrect.