### PR TITLE
Fix tags not appearing in success message

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -77,7 +77,6 @@ public class Messages {
                 .append(animal.getLocation())
                 .append("; Tags: ");
         animal.getTags().forEach(builder::append);
-
         return builder.toString();
     }
 


### PR DESCRIPTION
Fixed bug with success messages on animals,  where cli response was not showing the tags associated with that particular animal