### PR TITLE
Fix edit command error message

### DIFF
--- a/src/main/java/seedu/address/logic/parser/editCommandParser/EditAnimalCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/editCommandParser/EditAnimalCommandParser.java
@@ -11,11 +11,11 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditAnimalCommand;
 import seedu.address.logic.commands.EditAnimalCommand.EditAnimalDescriptor;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.logic.Messages;
 import seedu.address.model.Name;
 import seedu.address.model.tag.Tag;
 

--- a/src/main/java/seedu/address/logic/parser/editCommandParser/EditPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/editCommandParser/EditPersonCommandParser.java
@@ -11,11 +11,11 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditPersonCommand;
 import seedu.address.logic.commands.EditPersonCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.logic.Messages;
 import seedu.address.model.Name;
 import seedu.address.model.tag.Tag;
 


### PR DESCRIPTION
An invalid find command (e.g. `find person n/*&$`) now shows the invalid edit command message.

Subsequently `find person Alex Yeoh n/*&$` will then show the invalid name character message